### PR TITLE
Transform quaternion from Y-up (SLAM) to Z-up (geospatial)

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -249,6 +249,10 @@ def lambda_handler(event, context):
                 )
                 
                 # Calculate roll, pitch, yaw angles from quaternion
+                # Transform quaternion from Y-up (SLAM) to Z-up (geospatial)
+                temp_qy = qy
+                qy = -qz
+                qz = temp_qy
                 roll, pitch, yaw = quaternion_to_euler(qx, qy, qz, qw)
 
                 if np.isfinite(lon) and np.isfinite(lat):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved orientation calculations by switching to a geospatial coordinate system for roll, pitch, and yaw, ensuring more reliable and consistent measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->